### PR TITLE
MailChimp sign-up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'foundation-icons-sass-rails'
 gem 'haml-rails'
 
 gem 'google-api-client', '~> 0.9.20', require: 'google/apis/analytics_v3'
+gem 'mailchimp-api', require: 'mailchimp'
 gem 'rmagick', require: 'rmagick'
 gem 'gruff'
 
@@ -35,6 +36,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'timecop'
+  gem 'awesome_print', require: 'awesome_print'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
+    awesome_print (1.6.1)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -88,6 +89,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     eventmachine (1.2.1)
+    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -171,6 +173,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     jwt (1.5.6)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -186,6 +189,9 @@ GEM
     lumberjack (1.0.10)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mailchimp-api (2.0.6)
+      excon (>= 0.16.0)
+      json (>= 1.7.7)
     memoist (0.15.0)
     method_source (0.8.2)
     mime-types (3.1)
@@ -333,6 +339,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   capybara
   capybara-screenshot
   cucumber-rails
@@ -350,6 +357,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
+  mailchimp-api
   pg (~> 0.18)
   phantomjs
   poltergeist

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,7 +24,27 @@
 //                                                                  |___/
 //
 
+$(document).ready(function () {
+    $(function () {
+        $(document).foundation();
+    });
 
-$(function () {
-    $(document).foundation();
+
+    $('#subscribe').click(function () {
+        var email = $('#email').val();
+        $.ajax({
+                url: '/subscribe',
+                type: 'post',
+                dataType: 'json',
+                data: {email: email}
+            })
+            .done(function (data) {
+                console.log(data.message);
+                $('.subscribe').html('<strong>' + data.message + '</strong>');
+            })
+            .fail(function (data) {
+                $('.subscribe').append('<strong>' + data.responseJSON.message + '</strong>');
+            });
+    });
 });
+

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,23 @@
+class SubscriptionsController < ApplicationController
+  def subscribe
+    email = params[:email]
+    mailchimp = Mailchimp::API.new(ENV.fetch('MAILCHIMP_API_KEY'))
+
+    begin
+      mailchimp.lists.subscribe(ENV.fetch('MAILCHIMP_LIST_ID'),
+                                {email: email})
+      render json: {message: "Alright, we signed up: #{email} Thank you! We'll be in touch"}, status: 200
+    rescue Mailchimp::ListAlreadySubscribedError
+      render json: {message: "#{email} is already subscribed to the list"}, status: 400
+    rescue Mailchimp::ListDoesNotExistError
+      render json: {message: 'The list could not be found'}, status: 400
+      return
+    rescue Mailchimp::Error => ex
+      if ex.message
+        render json: {message: ex.message}, status: 400
+      else
+        render json: {message: 'An unknown error occurred'}, status: 400
+      end
+    end
+  end
+end

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -70,11 +70,12 @@
         %span.orange
           %strong FREE
         until June 2017.
-      .row.small-uncollapse.large-collapse
+      .row.small-uncollapse.large-collapse#subscribe_form
         .large-11.columns
-          %input{placeholder: 'Your Email', type: 'text'}/
+          %input{placeholder: 'Your Email', type: 'text', id: 'email'}/
         .large-1.columns
-          %a.orange-bg.button{href: '#'} Subscribe
+          %button.orange-bg.button{id: 'subscribe'} Subscribe
+
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,12 @@
 Rails.application.routes.draw do
 
+
   get 'setup', controller: :pages, action: :redirect
   get 'callback', controller: :pages, action: :callback
   get 'analytics', controller: :pages, action: :analytics
   get 'get_data', controller: :pages, action: :get_data, as: :get_data
+
+  post :subscribe, controller: :subscriptions, action: :subscribe
 
   root controller: :pages, action: :index
 

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,0 +1,3 @@
+Then(/^I should see "([^"]*)"$/) do |content|
+  expect(page).to have_content content
+end

--- a/features/step_definitions/basic_navigation_steps.rb
+++ b/features/step_definitions/basic_navigation_steps.rb
@@ -9,3 +9,7 @@ end
 Then(/^show me the page$/) do
   save_and_open_page
 end
+
+And(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, value|
+  fill_in element, with: value
+end

--- a/features/subscribe_to_news.feature
+++ b/features/subscribe_to_news.feature
@@ -1,0 +1,17 @@
+@javascript
+Feature: As a visitor
+  In order to stay in the loop about the development of Visualizer
+  I would like to be able to subscribe to a newsleter
+
+  Background:
+    Given I am on the landing page
+
+  Scenario: Sign up with email
+    And I fill in "Your Email" with "thomas@craftacademy.se"
+    And I click on "Subscribe"
+    Then I should see "Alright, we signed up: thomas@craftacademy.se Thank you! We'll be in touch"
+
+  Scenario: Sign up with badly formatted email
+    And I fill in "Your Email" with "thomascraftacademy.se"
+    And I click on "Subscribe"
+    Then I should see "An email address must contain a single @"


### PR DESCRIPTION
* adds `SubscriptionsContorller` with MailChimp signup action
* Note that the subscription flow is handeled with an ajax call to `SubscriptionsContorller#subscribe` that either returns a success message or errors by setting the response code to `400`  

<img width="1296" alt="skarmavbild 2016-11-27 kl 20 00 23" src="https://cloud.githubusercontent.com/assets/5248170/20650982/2bb57a30-b4dc-11e6-8d62-ccd600adfcf1.png">
